### PR TITLE
Change namespace and "compare" function name

### DIFF
--- a/semantic-versioning/README.md
+++ b/semantic-versioning/README.md
@@ -2,7 +2,7 @@
 
 This directory contains XSLT functions for working with semantic version numbers:
 
-* `v:compare`: Compare two semantic version strings for precedence. This function can also preprocess the input strings in certain ways to make them valid as semantic version strings.
+* `x3f:semver-compare`: Compare two semantic version strings for precedence. This function can also preprocess the input strings in certain ways to make them valid as semantic version strings.
 
 For background information about semantic versioning, see [Semantic Versioning 2.0.0](https://semver.org).
 

--- a/semantic-versioning/tests/version-util.xspec
+++ b/semantic-versioning/tests/version-util.xspec
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <x:description xmlns:x="http://www.jenitennison.com/xslt/xspec"
     xmlns:xs="http://www.w3.org/2001/XMLSchema"
-    xmlns:v="http://csrc.nist.gov/ns/version"
+    xmlns:x3f="http://csrc.nist.gov/ns/xslt3-functions"
     stylesheet="../version-util.xsl"
     xslt-version="3.0">
 
-    <x:scenario label="Tests for v:compare function with two parameters">
+    <x:scenario label="Tests for x3f:semver-compare function with two parameters">
         <x:scenario label="Difference in 1st number">
-            <x:call function="v:compare">
+            <x:call function="x3f:semver-compare">
                 <x:param select="'2.10.20'"/>
                 <x:param select="'1.20.30'"/>
             </x:call>
             <x:expect label="A is newer" select="xs:integer(1)"/>
         </x:scenario>
         <x:scenario label="Difference in 2nd number">
-            <x:call function="v:compare">
+            <x:call function="x3f:semver-compare">
                 <x:param select="'5.2.10'"/>
                 <x:param select="'5.1.20'"/>
             </x:call>
             <x:expect label="A is newer" select="xs:integer(1)"/>
         </x:scenario>
         <x:scenario label="Difference in 3rd number">
-            <x:call function="v:compare">
+            <x:call function="x3f:semver-compare">
                 <x:param select="'5.2.20'"/>
                 <x:param select="'5.2.10'"/>
             </x:call>
@@ -32,56 +32,56 @@
                 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0
             -->
             <x:scenario label="B equals A plus an extra part">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="'1.0.0-alpha'"/>
                     <x:param select="'1.0.0-alpha.1'"/>
                 </x:call>
                 <x:expect label="A is older" select="xs:integer(-1)"/>
             </x:scenario>
             <x:scenario label="B equals A plus an extra part (another example)">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="'1.0.0-beta'"/>
                     <x:param select="'1.0.0-beta.2'"/>
                 </x:call>
                 <x:expect label="A is older" select="xs:integer(-1)"/>
             </x:scenario>
             <x:scenario label="the A part is all-numeric, while B part has non-numeric character">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="'1.0.0-alpha.1'"/>
                     <x:param select="'1.0.0-alpha.beta'"/>
                 </x:call>
                 <x:expect label="A is older" select="xs:integer(-1)"/>
             </x:scenario>
             <x:scenario label="both parts have non-numeric characters">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="'1.0.0-alpha.beta'"/>
                     <x:param select="'1.0.0-beta'"/>
                 </x:call>
                 <x:expect label="A is older because alpha is before beta in ASCII sequence" select="xs:integer(-1)"/>
             </x:scenario>
             <x:scenario label="both parts have non-numeric characters (another example)">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="'1.0.0-beta.11'"/>
                     <x:param select="'1.0.0-rc.1'"/>
                 </x:call>
                 <x:expect label="A is older because beta is before rc in ASCII sequence" select="xs:integer(-1)"/>
             </x:scenario>
             <x:scenario label="both parts are all-numeric">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="'1.0.0-beta.2'"/>
                     <x:param select="'1.0.0-beta.11'"/>
                 </x:call>
                 <x:expect label="A is older because 2 is before 11 as numbers" select="xs:integer(-1)"/>
             </x:scenario>
             <x:scenario label="both parts are all-numeric, swapping order of input parameters">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="'1.0.0-beta.11'"/>
                     <x:param select="'1.0.0-beta.2'"/>
                 </x:call>
                 <x:expect label="A is newer because 11 is after 2 as numbers" select="xs:integer(1)"/>
             </x:scenario>
             <x:scenario label="A has a pre-release part and B does not">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="'1.0.0-rc.1'"/>
                     <x:param select="'1.0.0'"/>
                 </x:call>
@@ -90,14 +90,14 @@
         </x:scenario>
         <x:scenario label="A and B differ only in build metadata, ">
             <x:scenario label="with pre-release string">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="'1.0.0-alpha+001'"/>
                     <x:param select="'1.0.0-alpha+002'"/>
                 </x:call>
                 <x:expect label="A and B have the same precedence, because build metadata does not affect precedence" select="xs:integer(0)"/>
             </x:scenario>
             <x:scenario label="without pre-release string">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="'1.0.0+exp.sha.5114f85'"/>
                     <x:param select="'1.0.0+20130313144700'"/>
                 </x:call>
@@ -106,21 +106,21 @@
         </x:scenario>
         <x:scenario label="Improper form (two-parameter function does not make corrections)">
             <x:scenario label="First string has improper form" catch="yes">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="'1.0'"/>
                     <x:param select="'1.0.0'"/>
                 </x:call>
                 <x:expect label="Error" test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
             </x:scenario>
             <x:scenario label="Second string has improper form" catch="yes">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="'1.0.0'"/>
                     <x:param select="'1.0'"/>
                 </x:call>
                 <x:expect label="Error" test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
             </x:scenario>
             <x:scenario label="Both strings have identical improper form" catch="yes">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="'1.0'"/>
                     <x:param select="'1.0'"/>
                 </x:call>
@@ -129,10 +129,10 @@
         </x:scenario>        
     </x:scenario>
 
-    <x:scenario label="Tests for v:compare function with three parameters">
+    <x:scenario label="Tests for x3f:semver-compare function with three parameters">
         <x:scenario label="Normalize space ">
             <x:scenario label="in A">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="' 1.0.0-draft '"/>
                     <x:param select="'1.0.0-draft'"/>
                     <x:param select="map{'normalize-space': true()}"/>
@@ -140,7 +140,7 @@
                 <x:expect label="A and B are the same" select="xs:integer(0)"/>
             </x:scenario>
             <x:scenario label="in B">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="'1.0.0-draft'"/>
                     <x:param select="' 1.0.0-draft '"/>
                     <x:param select="map{'normalize-space': true()}"/>
@@ -150,7 +150,7 @@
         </x:scenario>
         <x:scenario label="Supply missing zeros ">
             <x:scenario label="in 'z' spot of A">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="'2.10-draft'"/>
                     <x:param select="'2.10.0-draft'"/>
                     <x:param select="map{'supply-missing-zeros': true()}"/>
@@ -158,7 +158,7 @@
                 <x:expect label="A and B are the same" select="xs:integer(0)"/>
             </x:scenario>
             <x:scenario label="in 'z' spot of B">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="'2.10.0'"/>
                     <x:param select="'2.10'"/>
                     <x:param select="map{'supply-missing-zeros': true()}"/>
@@ -166,7 +166,7 @@
                 <x:expect label="A and B are the same" select="xs:integer(0)"/>
             </x:scenario>
             <x:scenario label="in 'y' and 'z' spots of A">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="'5-draft'"/>
                     <x:param select="'5.0.0-draft'"/>
                     <x:param select="map{'supply-missing-zeros': true()}"/>
@@ -174,7 +174,7 @@
                 <x:expect label="A and B are the same" select="xs:integer(0)"/>
             </x:scenario>
             <x:scenario label="in 'y' and 'z' spots of B">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="'5.0.0'"/>
                     <x:param select="'5'"/>
                     <x:param select="map{'supply-missing-zeros': true()}"/>
@@ -184,7 +184,7 @@
         </x:scenario>
         <x:scenario label="Remove leading zeros ">
             <x:scenario label="in A">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="'010.020.030-rc010.00'"/>
                     <x:param select="'10.20.30-rc010.0'"/>
                     <x:param select="map{'remove-leading-zeros': true()}"/>
@@ -192,7 +192,7 @@
                 <x:expect label="A and B are the same" select="xs:integer(0)"/>
             </x:scenario>
             <x:scenario label="in B">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="'10.20.30-rc010.0'"/>
                     <x:param select="'010.020.030-rc010.00'"/>
                     <x:param select="map{'remove-leading-zeros': true()}"/>
@@ -200,7 +200,7 @@
                 <x:expect label="A and B are the same" select="xs:integer(0)"/>
             </x:scenario>
             <x:scenario label="in A and B">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="'010.020.030-rc010.00'"/>
                     <x:param select="'0010.0020.0030-rc010.000'"/>
                     <x:param select="map{'remove-leading-zeros': true()}"/>
@@ -208,7 +208,7 @@
                 <x:expect label="A and B are the same" select="xs:integer(0)"/>
             </x:scenario>
             <x:scenario label="at beginning and end">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="'0.020.030-rc010.00'"/>
                     <x:param select="'00.0020.0030-rc010.0'"/>
                     <x:param select="map{'remove-leading-zeros': true()}"/>
@@ -218,7 +218,7 @@
         </x:scenario>
         <x:scenario label="Allow empty string ">
             <x:scenario label="as first input">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="''"/>
                     <x:param select="'1.0.0'"/>
                     <x:param select="map{'allow-empty-string': true()}"/>
@@ -226,7 +226,7 @@
                 <x:expect label="B is newer" select="xs:integer(-1)"/>
             </x:scenario>
             <x:scenario label="as second input">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="'1.0.0'"/>
                     <x:param select="''"/>
                     <x:param select="map{'allow-empty-string': true()}"/>
@@ -234,7 +234,7 @@
                 <x:expect label="A is newer" select="xs:integer(1)"/>
             </x:scenario>
             <x:scenario label="for both inputs">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="''"/>
                     <x:param select="''"/>
                     <x:param select="map{'allow-empty-string': true()}"/>
@@ -244,7 +244,7 @@
         </x:scenario>
         <x:scenario label="Improper form even after modifications">
             <x:scenario label="First string has improper form" catch="yes">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="'!2.0.0'"/>
                     <x:param select="'1.0.0'"/>
                     <x:param select="map{}"/>
@@ -252,7 +252,7 @@
                 <x:expect label="Error" test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
             </x:scenario>
             <x:scenario label="Second string has improper form" catch="yes">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="'1.0.0'"/>
                     <x:param select="'!0'"/>
                     <x:param select="map{}"/>
@@ -260,7 +260,7 @@
                 <x:expect label="Error" test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
             </x:scenario>
             <x:scenario label="Both strings have identical improper form" catch="yes">
-                <x:call function="v:compare">
+                <x:call function="x3f:semver-compare">
                     <x:param select="'!1.0.0'"/>
                     <x:param select="'!1.0.0'"/>
                     <x:param select="map{}"/>
@@ -269,7 +269,7 @@
             </x:scenario>
         </x:scenario>
         <x:scenario label="Multiple modifications">
-            <x:call function="v:compare">
+            <x:call function="x3f:semver-compare">
                 <x:param select="' 01.00-draft '"/>
                 <x:param select="'1.0.0-draft'"/>
                 <x:param select="map{
@@ -283,10 +283,10 @@
         </x:scenario>
     </x:scenario>
     
-    <x:scenario label="Tests for v:normalize-version function">
+    <x:scenario label="Tests for x3f:normalize-version function">
         <x:scenario label="Multiple modifications requested">
             <x:scenario label="Spot check 1">
-                <x:call function="v:normalize-version">
+                <x:call function="x3f:normalize-version">
                     <x:param select="' 01.00-draft '"/>
                     <x:param select="map{
                         'normalize-space': true(),
@@ -297,7 +297,7 @@
                 <x:expect label="Removed space; inserted 0 for z; removed leading zeros" select="'1.0.0-draft'"/>
             </x:scenario>
             <x:scenario label="Spot check 2">
-                <x:call function="v:normalize-version">
+                <x:call function="x3f:normalize-version">
                     <x:param select="' 01.00-draft '"/>
                     <x:param select="map{
                         'normalize-space': true(),
@@ -307,7 +307,7 @@
                 <x:expect label="Removed space; inserted 0 for z; leading zeros unchanged" select="'01.00.0-draft'"/>
             </x:scenario>
             <x:scenario label="Spot check 3">
-                <x:call function="v:normalize-version">
+                <x:call function="x3f:normalize-version">
                     <x:param select="' 01.00-draft '"/>
                     <x:param select="map{
                         'normalize-space': true(),
@@ -319,7 +319,7 @@
         </x:scenario>
         <x:scenario label="No modifications requested">
             <x:scenario label="Explicit values of false">
-                <x:call function="v:normalize-version">
+                <x:call function="x3f:normalize-version">
                     <x:param select="' 01.00-draft '"/>
                     <x:param select="map{
                         'normalize-space': false(),
@@ -330,7 +330,7 @@
                 <x:expect label="Input string is unchanged" select="' 01.00-draft '"/>
             </x:scenario>
             <x:scenario label="Relevant options omitted, and unknown options supplied">
-                <x:call function="v:normalize-version">
+                <x:call function="x3f:normalize-version">
                     <x:param select="' 01.00-draft '"/>
                     <x:param select="map{
                         'unknown1': false(),
@@ -340,7 +340,7 @@
                 <x:expect label="Input string is unchanged" select="' 01.00-draft '"/>
             </x:scenario>
             <x:scenario label="Empty map">
-                <x:call function="v:normalize-version">
+                <x:call function="x3f:normalize-version">
                     <x:param select="' 01.00-draft '"/>
                     <x:param select="map{}"/>
                 </x:call>
@@ -349,23 +349,23 @@
         </x:scenario>
     </x:scenario>
 
-    <x:scenario label="Tests for v:normalize-space-option function">
+    <x:scenario label="Tests for x3f:normalize-space-option function">
         <x:scenario label="option = true">
-            <x:call function="v:normalize-space-option">
+            <x:call function="x3f:normalize-space-option">
                 <x:param select="' a b '"/>
                 <x:param select="true()"/>
             </x:call>
             <x:expect label="Input string without leading or trailing space" select="'a b'"/>
         </x:scenario>
         <x:scenario label="option = false">
-            <x:call function="v:normalize-space-option">
+            <x:call function="x3f:normalize-space-option">
                 <x:param select="' a b '"/>
                 <x:param select="false()"/>
             </x:call>
             <x:expect label="Input string unchanged" select="' a b '"/>
         </x:scenario>
         <x:scenario label="option = empty sequence">
-            <x:call function="v:normalize-space-option">
+            <x:call function="x3f:normalize-space-option">
                 <x:param select="' a b '"/>
                 <x:param select="()"/>
             </x:call>
@@ -373,44 +373,44 @@
         </x:scenario>
     </x:scenario>
 
-    <x:scenario label="Tests for v:supply-missing-zeros function">
+    <x:scenario label="Tests for x3f:supply-missing-zeros function">
         <x:scenario label="Missing z, prerelease string, option = true">
-            <x:call function="v:supply-missing-zeros">
+            <x:call function="x3f:supply-missing-zeros">
                 <x:param select="'2.10-draft.3'"/>
                 <x:param select="true()"/>
             </x:call>
             <x:expect label="z inserted" select="'2.10.0-draft.3'"/>
         </x:scenario>
         <x:scenario label="Missing y and z, prerelease string, option = true">
-            <x:call function="v:supply-missing-zeros">
+            <x:call function="x3f:supply-missing-zeros">
                 <x:param select="'2-draft.3'"/>
                 <x:param select="true()"/>
             </x:call>
             <x:expect label="y and z inserted" select="'2.0.0-draft.3'"/>
         </x:scenario>
         <x:scenario label="Missing z, no prerelease string, option = true">
-            <x:call function="v:supply-missing-zeros">
+            <x:call function="x3f:supply-missing-zeros">
                 <x:param select="'2.10'"/>
                 <x:param select="true()"/>
             </x:call>
             <x:expect label="z inserted" select="'2.10.0'"/>
         </x:scenario>
         <x:scenario label="Missing y and z, no prerelease string, option = true">
-            <x:call function="v:supply-missing-zeros">
+            <x:call function="x3f:supply-missing-zeros">
                 <x:param select="'2'"/>
                 <x:param select="true()"/>
             </x:call>
             <x:expect label="y and z inserted" select="'2.0.0'"/>
         </x:scenario>
         <x:scenario label="option = false">
-            <x:call function="v:supply-missing-zeros">
+            <x:call function="x3f:supply-missing-zeros">
                 <x:param select="'1.2-draft.3'"/>
                 <x:param select="false()"/>
             </x:call>
             <x:expect label="Input string unchanged" select="'1.2-draft.3'"/>
         </x:scenario>
         <x:scenario label="option = empty sequence">
-            <x:call function="v:supply-missing-zeros">
+            <x:call function="x3f:supply-missing-zeros">
                 <x:param select="'1.2-draft.3'"/>
                 <x:param select="()"/>
             </x:call>
@@ -418,9 +418,9 @@
         </x:scenario>
     </x:scenario>
 
-    <x:scenario label="Tests for v:remove-leading-zeros">
+    <x:scenario label="Tests for x3f:remove-leading-zeros">
         <x:scenario label="option = true">
-            <x:call function="v:remove-leading-zeros">
+            <x:call function="x3f:remove-leading-zeros">
                 <x:param select="'010.020.030-rc010.-010.020'"/>
                 <x:param select="true()"/>
             </x:call>
@@ -428,7 +428,7 @@
                 select="'10.20.30-rc010.-010.20'"/>
         </x:scenario>
         <x:scenario label="option = true, no prerelease part">
-            <x:call function="v:remove-leading-zeros">
+            <x:call function="x3f:remove-leading-zeros">
                 <x:param select="'010.020.030'"/>
                 <x:param select="true()"/>
             </x:call>
@@ -436,14 +436,14 @@
                 select="'10.20.30'"/>
         </x:scenario>
         <x:scenario label="option = false">
-            <x:call function="v:remove-leading-zeros">
+            <x:call function="x3f:remove-leading-zeros">
                 <x:param select="'010.020.030-rc010.-010.020'"/>
                 <x:param select="false()"/>
             </x:call>
             <x:expect label="Input string unchanged" select="'010.020.030-rc010.-010.020'"/>
         </x:scenario>
         <x:scenario label="option = empty sequence">
-            <x:call function="v:remove-leading-zeros">
+            <x:call function="x3f:remove-leading-zeros">
                 <x:param select="'010.020.030-rc010.-010.020'"/>
                 <x:param select="()"/>
             </x:call>
@@ -451,30 +451,30 @@
         </x:scenario>
     </x:scenario>
 
-    <x:scenario label="Tests for v:version-to-xyz function">
+    <x:scenario label="Tests for x3f:version-to-xyz function">
         <x:scenario label="String with three dot-separated numeric parts">
-            <x:call function="v:version-to-xyz">
+            <x:call function="x3f:version-to-xyz">
                 <x:param select="'1.22.333'"/>
                 <x:param select="false()"/>
             </x:call>
             <x:expect label="Sequence of three numbers as strings" select="('1', '22', '333')"/>
         </x:scenario>
         <x:scenario label="String with two dot-separated numeric parts">
-            <x:call function="v:version-to-xyz">
+            <x:call function="x3f:version-to-xyz">
                 <x:param select="'1.22'"/>
                 <x:param select="true()"/>
             </x:call>
             <x:expect label="Sequence of three numbers as strings with zero in 3rd spot" select="('1', '22', '0')"/>
         </x:scenario>
         <x:scenario label="String with one number">
-            <x:call function="v:version-to-xyz">
+            <x:call function="x3f:version-to-xyz">
                 <x:param select="'1'"/>
                 <x:param select="true()"/>
             </x:call>
             <x:expect label="Sequence of three numbers as strings with zero in 2nd and 3rd spot" select="('1', '0', '0')"/>
         </x:scenario>
         <x:scenario label="String with hyphen between the numbers">
-            <x:call function="v:version-to-xyz">
+            <x:call function="x3f:version-to-xyz">
                 <x:param select="'1-22-333'"/>
                 <x:param select="true()"/>
             </x:call>
@@ -482,7 +482,7 @@
             <x:expect label="Sequence of three numbers as strings with zero in 2nd and 3rd spot" select="('1', '0', '0')"/>
         </x:scenario>
         <x:scenario label="Fewer than 3 dot-separated numbers, and 2nd input is false">
-            <x:call function="v:version-to-xyz">
+            <x:call function="x3f:version-to-xyz">
                 <x:param select="'1:22:333'"/>
                 <x:param select="false()"/>
             </x:call>
@@ -490,14 +490,14 @@
         </x:scenario>
         <x:scenario label="Error cases">
             <x:scenario label="Empty string" catch="yes">
-                <x:call function="v:version-to-xyz">
+                <x:call function="x3f:version-to-xyz">
                     <x:param select="''"/>
                     <x:param select="false()"/>
                 </x:call>
                 <x:expect label="Error" test="$x:result instance of map(*) and $x:result('err') instance of map(*)"/>
             </x:scenario>
             <x:scenario label="String with non-numeric first character" catch="yes">
-                <x:call function="v:version-to-xyz">
+                <x:call function="x3f:version-to-xyz">
                     <x:param select="'v1.22.333'"/>
                     <x:param select="false()"/>
                 </x:call>

--- a/semantic-versioning/version-util.xsl
+++ b/semantic-versioning/version-util.xsl
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-    xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:v="http://csrc.nist.gov/ns/version"
-    exclude-result-prefixes="xs v" version="3.0">
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    xmlns:x3f="http://csrc.nist.gov/ns/xslt3-functions"
+    exclude-result-prefixes="xs x3f" version="3.0">
 
     <!-- Reference for Semantic Versioning 2.0.0: semver.org -->
 
@@ -21,7 +22,7 @@
         *  0 if $A and $B indicate the same version, not counting build metadata
         *  1 if $A is newer than $B
     -->
-    <xsl:function name="v:compare" as="xs:integer">
+    <xsl:function name="x3f:semver-compare" as="xs:integer">
         <xsl:param name="A" as="xs:string"/>
         <xsl:param name="B" as="xs:string"/>
 
@@ -41,9 +42,9 @@
         <xsl:variable name="A-trunc" as="xs:string" select="$remove-build-metadata($A)"/>
         <xsl:variable name="B-trunc" as="xs:string" select="$remove-build-metadata($B)"/>
         <xsl:variable name="A-numeric-parts" as="xs:integer+"
-            select="v:version-to-xyz(normalize-space($A-trunc), false()) ! xs:integer(.)"/>
+            select="x3f:version-to-xyz(normalize-space($A-trunc), false()) ! xs:integer(.)"/>
         <xsl:variable name="B-numeric-parts" as="xs:integer+"
-            select="v:version-to-xyz(normalize-space($B-trunc), false()) ! xs:integer(.)"/>
+            select="x3f:version-to-xyz(normalize-space($B-trunc), false()) ! xs:integer(.)"/>
 
         <!-- Check if the x.y.z parts of $A and $B differ. After finding a difference,
             break out of the loop because the remainder of the string is irrelevant. -->
@@ -166,7 +167,7 @@
         *  0 if $A and $B indicate the same version, not counting build metadata
         *  1 if $A is newer than $B
     -->
-    <xsl:function name="v:compare" as="xs:integer">
+    <xsl:function name="x3f:semver-compare" as="xs:integer">
         <xsl:param name="A" as="xs:string"/>
         <xsl:param name="B" as="xs:string"/>
         <xsl:param name="options" as="map(*)?"/>
@@ -175,13 +176,13 @@
                 <xsl:sequence select="compare($A, $B)"/>
             </xsl:when>
             <xsl:otherwise>
-                <!-- Modify $A and $B as $options indicates, and call the v:compare
+                <!-- Modify $A and $B as $options indicates, and call the x3f:semver-compare
                     function implementation that assumes valid inputs. At that point,
                     if either input is still not a valid Semantic Version 2.0.0
                     string, that function will issue a fatal error. -->
-                <xsl:sequence select="v:compare(
-                    v:normalize-version($A, $options),
-                    v:normalize-version($B, $options)
+                <xsl:sequence select="x3f:semver-compare(
+                    x3f:normalize-version($A, $options),
+                    x3f:normalize-version($B, $options)
                     )"/>
             </xsl:otherwise>
         </xsl:choose>
@@ -201,13 +202,13 @@
           * 'supply-missing-zeros': If true, supply missing y or z as zero.
           * 'remove-leading-zeros': If true, remove leading zeros from x, y, or z.        
     -->
-    <xsl:function name="v:normalize-version" as="xs:string">
+    <xsl:function name="x3f:normalize-version" as="xs:string">
         <xsl:param name="str" as="xs:string"/>
         <xsl:param name="options" as="map(*)"/>
         <xsl:sequence select="$str
-            => v:normalize-space-option($options('normalize-space'))
-            => v:supply-missing-zeros($options('supply-missing-zeros'))
-            => v:remove-leading-zeros($options('remove-leading-zeros'))
+            => x3f:normalize-space-option($options('normalize-space'))
+            => x3f:supply-missing-zeros($options('supply-missing-zeros'))
+            => x3f:remove-leading-zeros($options('remove-leading-zeros'))
             "/>
     </xsl:function>
 
@@ -219,7 +220,7 @@
     
         Assumptions about content of $str: None
     -->
-    <xsl:function name="v:normalize-space-option" as="xs:string">
+    <xsl:function name="x3f:normalize-space-option" as="xs:string">
         <xsl:param name="str" as="xs:string"/>
         <xsl:param name="option" as="xs:boolean?"/>
         <xsl:sequence select="if ($option) then normalize-space($str) else $str"/>
@@ -233,7 +234,7 @@
         identifiers separated by dots, optionally followed by a hyphen and
         more string content.
     -->
-    <xsl:function name="v:supply-missing-zeros" as="xs:string">
+    <xsl:function name="x3f:supply-missing-zeros" as="xs:string">
         <xsl:param name="str" as="xs:string"/>
         <xsl:param name="option" as="xs:boolean?"/>
         <xsl:choose>
@@ -242,7 +243,7 @@
                     select="substring-after($str,'-')"/>
                 <xsl:variable name="modified-xyz-part" as="xs:string"
                     select="$str
-                    => v:version-to-xyz(true())
+                    => x3f:version-to-xyz(true())
                     => string-join('.')
                     "/>
                 <xsl:sequence select="
@@ -265,7 +266,7 @@
         identifiers, optionally followed by a hyphen and another
         series of dot-separated identifiers.
     -->
-    <xsl:function name="v:remove-leading-zeros" as="xs:string">
+    <xsl:function name="x3f:remove-leading-zeros" as="xs:string">
         <xsl:param name="str" as="xs:string"/>
         <xsl:param name="option" as="xs:boolean?"/>
         <xsl:choose>
@@ -320,7 +321,7 @@
         numeric identifiers separated by dots, optionally followed by more
         string content that the function ignores.
     -->
-    <xsl:function name="v:version-to-xyz" as="xs:string+">
+    <xsl:function name="x3f:version-to-xyz" as="xs:string+">
         <xsl:param name="ver" as="xs:string"/>
         <xsl:param name="supply-missing-zeros" as="xs:boolean"/>
         <xsl:analyze-string select="$ver" regex="^([0-9]+)(\.([0-9]+))?(\.([0-9]+))?">


### PR DESCRIPTION
For all functions in `version-util.xsl`, change namespace to the same one decided upon in #3. Also, change the function name from `compare` to `semver-compare` now that the namespace is not specific to version identifier utilities.

Closes #4.

## Testing Done

- Validated the .xsl and .xspec files
- Ran all tests in `version-util.xspec`; 59 passing tests, 0 pending, 0 failures


